### PR TITLE
修改seumasterthesis.bst，让\citet总是显示为xxx等人而不是根据entry的语言判断

### DIFF
--- a/seumasterthesis.bst
+++ b/seumasterthesis.bst
@@ -130,7 +130,7 @@ FUNCTION {bbl.et.al}
 }
 
 FUNCTION {citation.et.al}
-{ bbl.et.al }
+{ "等人" }
 
 FUNCTION {bbl.colon} { ": " }
 


### PR DESCRIPTION
例如

```
[23] LIU P, WANG G, LI H, et al. Multi-granularity cross-modal representation learning for named entity recognition on social media[J]. Information Processing & Management, 2024, 61(1):103546.
```

使用`\cite{liu2024multi}`应该显示“Liu 等人[1]”，而按照原来的bst文件会显示“Liu et al.[1]”